### PR TITLE
feat: Improve reset password flow and email configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # General configuration
+APP_URL=http://localhost:3333
 TZ=UTC
 PORT=3333
 HOST=localhost
@@ -25,3 +26,4 @@ S3_ENDPOINT=
 # Mail configuration
 SMTP_HOST=
 SMTP_PORT=
+EMAIL_FROM=

--- a/app/auth/controllers/reset_password_controller.ts
+++ b/app/auth/controllers/reset_password_controller.ts
@@ -14,7 +14,13 @@ export default class ResetPasswordController {
     /**
      * Render the "Reset Password" page.
      */
-    return inertia.render('auth/reset_password')
+    const email = request.param('email')
+    const signature = request.input('signature')
+
+    return inertia.render('auth/reset_password', {
+      email,
+      signature,
+    })
   }
 
   async handle({ request, params, response }: HttpContext) {

--- a/app/auth/emails/reset_password_email.tsx
+++ b/app/auth/emails/reset_password_email.tsx
@@ -11,6 +11,7 @@ import {
   Text,
 } from '@react-email/components'
 import User from '#common/models/user'
+import React from 'react'
 
 interface ResetPasswordEmailProps {
   user: User

--- a/app/auth/lang/de.json
+++ b/app/auth/lang/de.json
@@ -28,6 +28,6 @@
   "change_password": "Passwort ändern",
   "invalid_credentials": "Ungültige Anmeldedaten",
   "email_sent_title": "E-Mail gesendet",
-  "email_sent_description": "Eine E-Mail zum Zurücksetzen des Passworts wurde an die mit deinem Konto verknüpfte E-Mail-Adresse gesendet."
+  "email_sent_description": "Eine E-Mail zum Zurücksetzen des Passworts wurde an die mit deinem Konto verknüpfte E-Mail-Adresse gesendet.",
+  "confirmation_password_label": "Passwort bestätigen"
 }
-  

--- a/app/auth/lang/en.json
+++ b/app/auth/lang/en.json
@@ -28,5 +28,6 @@
   "change_password": "Change Password",
   "invalid_credentials": "Invalid credentials",
   "email_sent_title": "Email sent",
-  "email_sent_description": "A password reset email has been sent to the email address associated with your account."
+  "email_sent_description": "A password reset email has been sent to the email address associated with your account.",
+  "confirmation_password_label": "Confirm Password"
 }

--- a/app/auth/lang/fr.json
+++ b/app/auth/lang/fr.json
@@ -28,5 +28,6 @@
   "change_password": "Changer de mot de passe",
   "invalid_credentials": "Identifiants invalides",
   "email_sent_title": "Courriel envoyé",
-  "email_sent_description": "Un courriel de réinitialisation de mot de passe a été envoyé à l'adresse électronique associée à votre compte."
+  "email_sent_description": "Un courriel de réinitialisation de mot de passe a été envoyé à l'adresse électronique associée à votre compte.",
+  "confirmation_password_label": "Confirmer le mot de passe"
 }

--- a/app/auth/lang/ne.json
+++ b/app/auth/lang/ne.json
@@ -28,5 +28,6 @@
   "change_password": "पासवर्ड परिवर्तन गर्नुहोस्",
   "invalid_credentials": "प्रयोगकर्ता नाम वा पासवर्ड गलत छ",
   "email_sent_title": "इमेल पठाइयो",
-  "email_sent_description": "तपाईंको इमेलमा पासवर्ड रिसेट लिङ्क पठाइएको छ।"
+  "email_sent_description": "तपाईंको इमेलमा पासवर्ड रिसेट लिङ्क पठाइएको छ।",
+  "confirmation_password_label": "पासवर्ड पुष्टि गर्नुहोस्"
 }

--- a/app/auth/notifications/reset_password_notification.ts
+++ b/app/auth/notifications/reset_password_notification.ts
@@ -1,33 +1,26 @@
 import env from '#start/env'
 import { BaseMail } from '@adonisjs/mail'
-// import router from '@adonisjs/core/services/router'
 import User from '#common/models/user'
+import ResetPasswordEmail from '#auth/emails/reset_password_email'
+import router from '@adonisjs/core/services/router'
+import { renderToString } from 'react-dom/server'
 
 export default class ResetPasswordNotification extends BaseMail {
-  from = env.get('EMAIL_FROM')
+  from = `Panache <${env.get('MAIL_FROM_ADDRESS')}>`
   subject = `Reset your password for Panache`
 
   constructor(private user: User) {
     super()
   }
-
-  /**
-   * The "prepare" method is called automatically when
-   * the email is sent or queued.
-   */
   async prepare() {
-    /**
-     * Generate a signed URL with the user's email,
-     * which can be used to reset the password.
-     */
-    // const signedUrl = router.makeSignedUrl(
-    //   'auth.reset_password.show',
-    //   { email: this.user.email },
-    //   { expiresIn: '30m', prefixUrl: env.get('APP_URL'), purpose: 'reset_password' }
-    // )
 
+    const signedUrl = router.makeSignedUrl(
+      'auth.reset_password.show',
+      { email: this.user.email },
+      { expiresIn: '15m', prefixUrl: env.get('APP_URL'), purpose: 'reset_password' }
+    )
     this.message.to(this.user.email)
-
-    this.message.html('emailHtml')
+    const html = renderToString(ResetPasswordEmail({ user: this.user, signedUrl }))
+    this.message.html(html)
   }
 }

--- a/app/auth/notifications/reset_password_notification.ts
+++ b/app/auth/notifications/reset_password_notification.ts
@@ -6,7 +6,7 @@ import router from '@adonisjs/core/services/router'
 import { renderToString } from 'react-dom/server'
 
 export default class ResetPasswordNotification extends BaseMail {
-  from = `Panache <${env.get('MAIL_FROM_ADDRESS')}>`
+  from = `Panache <${env.get('EMAIL_FROM')}>`
   subject = `Reset your password for Panache`
 
   constructor(private user: User) {

--- a/app/auth/ui/components/forgot_password_form.tsx
+++ b/app/auth/ui/components/forgot_password_form.tsx
@@ -18,13 +18,16 @@ import { CircleCheckIcon } from 'lucide-react'
 export function ForgotPasswordForm({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) {
   const t = useTranslate('auth')
   const [success, setSuccess] = React.useState(false)
-  const form = useForm({
+
+  const  { setData, post, processing, errors }  = useForm({
     email: '',
   })
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    form.post('/auth/forgot_password', {
+    post('/auth/forgot_password', {
       onSuccess: () => setSuccess(true),
+      onError: () => setSuccess(false),
     })
   }
 
@@ -58,10 +61,14 @@ export function ForgotPasswordForm({ className, ...props }: React.ComponentProps
                     placeholder={t('email_placeholder')}
                     required
                     className="pr-20"
+                    onChange={(e) => setData('email', e.target.value)}
                   />
+                  {errors.email && (
+                    <p className="text-red-500 text-sm">{errors.email}</p> // TODO: Add translation
+                  )}
                 </div>
-                <Button type="submit" className="!w-full">
-                  {t('send_reset_link')}
+                <Button type="submit" className="!w-full" disabled={processing}>
+                  {processing ? t('sending') : t('send_reset_link')}
                 </Button>
               </div>
             </form>

--- a/app/auth/ui/components/reset_password_form.tsx
+++ b/app/auth/ui/components/reset_password_form.tsx
@@ -11,36 +11,70 @@ import {
 import { Input } from '#common/ui/components/input'
 import { Label } from '#common/ui/components/label'
 import useTranslate from '#common/ui/hooks/use_translate'
+import { useForm, usePage } from '@inertiajs/react'
+
+type inertiaProps = {
+  email: string
+  signature: string
+}
 
 export function ResetPasswordForm({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) {
   const t = useTranslate('auth')
+  const { setData, post, processing, errors } = useForm({
+    password: '',
+    confirmationPassword: '',
+  })
+  const { email, signature } = usePage<inertiaProps>().props
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    post(`/auth/reset_password/${email}?signature=${signature}`)
+  }
 
   return (
     <div className={cn('flex flex-col gap-6', className)} {...props}>
       <Card>
         <CardHeader className="text-center">
           <CardTitle className="text-4xl font-normal font-serif">
-            {t('forgot_password_title')}
+            {t('reset_password_title')}
           </CardTitle>
-          <CardDescription>{t('forgot_password_description')}</CardDescription>
+          <CardDescription>{t('reset_password_description')}
+          </CardDescription>
         </CardHeader>
         <CardContent>
-          <form>
+          <form onSubmit={handleSubmit}>
             <div className="grid gap-5">
               <div className="grid gap-2">
-                <Label htmlFor="email">{t('email_label')}</Label>
+                <Label htmlFor="password">{t('password_label')}</Label>
                 <Input
-                  autoComplete="panache-email"
-                  id="email"
-                  name="email"
-                  type="text"
-                  placeholder={t('email_placeholder')}
+                  id="password"
+                  name="password"
+                  type="password"
+                  placeholder='********'
                   required
                   className="pr-20"
+                  onChange={(e) => setData('password', e.target.value)}
                 />
               </div>
-              <Button type="submit" className="!w-full">
-                {t('send_reset_link')}
+              <div className="grid gap-2">
+                <Label htmlFor="confirmationPassword">
+                  {t('confirmation_password_label')}
+                </Label>
+                <Input
+                  id="confirmationPassword"
+                  name="confirmationPassword"
+                  type="password"
+                  placeholder='********'
+                  required
+                  className="pr-20"
+                  onChange={(e) => setData('confirmationPassword', e.target.value)}
+                />
+                {errors.password && (
+                  <p className="text-red-500 text-sm">{errors.password}</p> // TODO: Add translation
+                )}
+              </div>
+              <Button type="submit" className="!w-full" disabled={processing}>
+                {t('change_password')}
               </Button>
             </div>
           </form>

--- a/app/auth/ui/components/sign_in_form.tsx
+++ b/app/auth/ui/components/sign_in_form.tsx
@@ -80,7 +80,7 @@ export function SignInForm({ className, ...props }: React.ComponentPropsWithoutR
 
           {/* Password Field */}
           <div className="grid gap-2">
-            {/* <div className="flex items-center">
+            <div className="flex items-center">
               <Label htmlFor="password">{t('password_label')}</Label>
               <Link
                 href="/auth/forgot_password"
@@ -88,7 +88,7 @@ export function SignInForm({ className, ...props }: React.ComponentPropsWithoutR
               >
                 {t('forgot_password')}
               </Link>
-            </div> */}
+            </div>
             <Input
               id="password"
               type="password"

--- a/compose.yml
+++ b/compose.yml
@@ -25,6 +25,13 @@ services:
       - 8900:8900
       - 9000:9000
 
+  mailhog:
+    image: mailhog/mailhog
+    container_name: mailhog
+    ports:
+      - "8025:8025"
+      - "1025:1025"
+
 volumes:
   panache_postgres_data:
   panache_minio_data:

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -15,7 +15,7 @@ router.get('/auth/sign_up', [SignUpController, 'show'])
 router.post('/auth/sign_up', [SignUpController, 'handle'])
 
 const SignInController = () => import('#auth/controllers/sign_in_controller')
-router.get('/auth/sign_in', [SignInController, 'show'])
+router.get('/auth/sign_in', [SignInController, 'show']).as('auth.sign_in.show')
 router.post('/auth/sign_in', [SignInController, 'handle'])
 
 const SignOutController = () => import('#auth/controllers/sign_out_controller')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@adonisjs/tsconfig/tsconfig.app.json",
   "compilerOptions": {
     "rootDir": "./",
-    "outDir": "./build"
+    "outDir": "./build",
+    "jsx": "react"
   },
   "exclude": ["node_modules", "build", "app/**/*.tsx", "resources/**/*"]
 }


### PR DESCRIPTION
### Reset Password 

- Added a reset password form with validation, error handling, and loading states.  
- Updated the reset password email notification to include signed URL expiration and rendered email content properly.  
- I passed the email and signature to the reset password page for better handling.
- Improved the forgot password form with better error handling and a loading state.  

### Email & Config Updates 
- Updated `.env.example` with email configuration changes.  
- Added a confirmation password label translation for `de`, `en`, `fr`, and `ne`.  
- Added MailHog to `docker-compose` for local email testing.  

### Other Fixes  
- Enabled JSX support in TypeScript config. 
- Added a route alias for the sign-in controller to redirect users after changing their password.

https://github.com/user-attachments/assets/6deca171-3c13-4187-80dd-67a85eaccbd0
