### PR TITLE
feat: searchParams inertia way of doing it without full page refresh for sorting and search components

### DIFF
--- a/app/social/ui/components/comments/sort_comment_select.tsx
+++ b/app/social/ui/components/comments/sort_comment_select.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-
+import { router } from '@inertiajs/react'
 import {
   Select,
   SelectContent,
@@ -12,22 +12,22 @@ import {
 import useTranslate from '#common/ui/hooks/use_translate'
 import { ArrowDownWideNarrowIcon } from 'lucide-react'
 import useQuery from '#common/ui/hooks/use_query'
+import usePath from '#common/ui/hooks/use_path'
 
 export function SortCommentSelect() {
   const t = useTranslate('social')
   const query = useQuery()
+  const path = usePath()
   const [method, setMethod] = React.useState(query.method || 'popular')
 
-  const [loaded, setLoaded] = React.useState(false)
-
   React.useEffect(() => {
-    setLoaded(true)
-  }, [])
+    const params = new URLSearchParams(query)
+    params.set('method', method)
 
-  React.useEffect(() => {
-    if (!loaded) return
-
-    window.location.search = `method=${method}`
+    router.get(path, Object.fromEntries(params), {
+      preserveState: false,
+      preserveScroll: true,
+    })
   }, [method])
 
   return (

--- a/app/social/ui/components/comments/sort_comment_select.tsx
+++ b/app/social/ui/components/comments/sort_comment_select.tsx
@@ -20,7 +20,15 @@ export function SortCommentSelect() {
   const path = usePath()
   const [method, setMethod] = React.useState(query.method || 'popular')
 
+  const [loaded, setLoaded] = React.useState(false)
+
   React.useEffect(() => {
+    setLoaded(true)
+  }, [])
+
+  React.useEffect(() => {
+    if (!loaded) return
+
     const params = new URLSearchParams(query)
     params.set('method', method)
 

--- a/app/social/ui/components/search_input.tsx
+++ b/app/social/ui/components/search_input.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, FormEvent } from 'react'
 import { Search, X } from 'lucide-react'
 import React from 'react'
 import { Input } from '#common/ui/components/input'
@@ -8,6 +8,7 @@ import { Button } from '#common/ui/components/button'
 import useTranslate from '#common/ui/hooks/use_translate'
 import useQuery from '#common/ui/hooks/use_query'
 import usePath from '#common/ui/hooks/use_path'
+import { router } from '@inertiajs/react'
 
 interface SearchInputProps {
   className?: string
@@ -21,8 +22,24 @@ export function SearchInput({ className = '' }: SearchInputProps) {
   const t = useTranslate()
   const query = useQuery()
   const [searchTerm, setSearchTerm] = useState(query.search || '')
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+
+    const params = searchTerm ? { search: searchTerm } : {}
+
+    router.get(isExplore ? path : '/rooms', params, {
+      preserveState: false,
+      preserveScroll: true,
+    })
+  }
+
+  const handleClear = () => {
+    setSearchTerm('')
+  }
+
   return (
-    <form className={`relative ${className}`} action={isExplore ? path : '/rooms'} method="get">
+    <form className={`relative ${className}`} onSubmit={handleSubmit}>
       <button type="submit" hidden></button>
       <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
       <Input
@@ -39,7 +56,7 @@ export function SearchInput({ className = '' }: SearchInputProps) {
           variant="ghost"
           size="icon"
           className="absolute right-1 top-1/2 h-8 w-8 -translate-y-1/2"
-          onClick={() => setSearchTerm('')}
+          onClick={handleClear}
         >
           <X className="h-4 w-4" />
         </Button>

--- a/app/social/ui/components/sort_by_select.tsx
+++ b/app/social/ui/components/sort_by_select.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-
+import { router } from '@inertiajs/react'
 import {
   Select,
   SelectContent,
@@ -12,27 +12,30 @@ import {
 import useTranslate from '#common/ui/hooks/use_translate'
 import { ArrowDownWideNarrowIcon, ClockIcon } from 'lucide-react'
 import useQuery from '#common/ui/hooks/use_query'
+import usePath from '#common/ui/hooks/use_path'
 
 export function SortBySelect() {
   const t = useTranslate('social')
   const query = useQuery()
+  const path = usePath()
   const [method, setMethod] = React.useState(query.method || 'popular')
   const [period, setPeriod] = React.useState(query.period || 'day')
 
-  const [loaded, setLoaded] = React.useState(false)
-
   React.useEffect(() => {
-    setLoaded(true)
-  }, [])
-
-  React.useEffect(() => {
-    if (!loaded) return
+    const params = new URLSearchParams(query)
 
     if (method === 'new') {
-      window.location.search = `method=new`
+      params.set('method', 'new')
+      params.delete('period')
     } else {
-      window.location.search = `method=${method}&period=${period}`
+      params.set('method', method)
+      params.set('period', period)
     }
+
+    router.get(path, Object.fromEntries(params), {
+      preserveState: false,
+      preserveScroll: true,
+    })
   }, [method, period])
 
   return (

--- a/app/social/ui/components/sort_by_select.tsx
+++ b/app/social/ui/components/sort_by_select.tsx
@@ -21,7 +21,15 @@ export function SortBySelect() {
   const [method, setMethod] = React.useState(query.method || 'popular')
   const [period, setPeriod] = React.useState(query.period || 'day')
 
+  const [loaded, setLoaded] = React.useState(false)
+
   React.useEffect(() => {
+    setLoaded(true)
+  }, [])
+
+  React.useEffect(() => {
+    if (!loaded) return
+    
     const params = new URLSearchParams(query)
 
     if (method === 'new') {


### PR DESCRIPTION
Hi, basically here i modified 3 files to achieve the goal which was to not have that bad UX when sorting and searching which caused a full page refresh and is very old school way of doing it and not used anymore. 

- So now the searchParams in URL change has the same UX as navigation of links, Inertia.js router.get() you have fresh data every time searchParams change this was the goal while preserving the scroll posiiton.

- Also in the search input component used not the old school method action but instead a handler function in which uses Inertia router.get to send the HTTP request to the server and gets the data without causing any full page reload there too.

 I also tested the changes locally with some little data after setting it up and seems correct but of course more testing can be done.